### PR TITLE
Source savu_setup to have exports take effect

### DIFF
--- a/install/mpi_cpu_test.sh
+++ b/install/mpi_cpu_test.sh
@@ -7,7 +7,7 @@ if ! [ "$output" ]; then
 fi
 
 # set the TESTDATA environment variable
-savu_setup.sh
+. savu_setup.sh
 
 echo "Running the mpi cpu test..."
 savu_launcher.sh $TESTDATA/data/24737.nxs $TESTDATA/test_process_lists/mpi_cpu_test.nxs $output

--- a/install/mpi_gpu_test.sh
+++ b/install/mpi_gpu_test.sh
@@ -7,7 +7,7 @@ if ! [ "$output" ]; then
 fi
 
 # set the TESTDATA environment variable
-savu_setup.sh
+. savu_setup.sh
 
 echo "Running the mpi gpu test..."
 savu_launcher.sh $TESTDATA/data/24737.nxs $TESTDATA/test_process_lists/mpi_gpu_test.nxs $output


### PR DESCRIPTION
The scripts `mpi_cpu_tests.sh` and `mpi_gpu_tests.sh` executed `savu_setup.sh` instead of sourcing it to have the export of `TESTDATA` inside take effect.