### PR TITLE
Add missing return in TomoPy citation_information

### DIFF
--- a/savu/plugins/reconstructions/tomopy_recon.py
+++ b/savu/plugins/reconstructions/tomopy_recon.py
@@ -154,3 +154,4 @@ class TomopyRecon(BaseRecon, CpuPlugin):
              "%D 2014" +
              "%I International Union of Crystallography")
         cite_info.doi = "doi: 10.1107/S1600577514013939"
+        return cite_info


### PR DESCRIPTION
`return` was missing in `TomopyRecon:citation_information()` so no citation was being written for the TomoPy reconstruction plugin.