### PR TITLE
Generalize dosna parameters

### DIFF
--- a/savu/core/transports/dosna_transport.py
+++ b/savu/core/transports/dosna_transport.py
@@ -36,10 +36,6 @@ log = logging.getLogger(__name__)
 DEFAULT_CONNECTION = "savu-data"
 DEFAULT_BACKEND = "ceph"
 DEFAULT_ENGINE = "mpi"
-DEFAULT_CEPH_CONFFILE = "ceph.conf"
-DEFAULT_CEPH_CLIENT_ID = "dls"
-DEFAULT_HDF5_DIR = "/tmp"
-
 
 class DosnaTransport(BaseTransport):
     """Transport implementation to use DosNa for managing storage and
@@ -64,19 +60,14 @@ class DosnaTransport(BaseTransport):
 
         backend = options.get("dosna_backend") or DEFAULT_BACKEND
         engine = options.get("dosna_engine") or DEFAULT_ENGINE
-
         dosna_connection = options.get("dosna_connection") \
             or DEFAULT_CONNECTION
+        dosna_connection_options = options.get("dosna_conection_options")
+
         dosna_options = {}
 
-        if backend == "ceph":
-            dosna_options["conffile"] = options.get("dosna_ceph_conffile") \
-                or DEFAULT_CEPH_CONFFILE
-            dosna_options["client_id"] = options.get("dosna_ceph_client_id") \
-                or DEFAULT_CEPH_CLIENT_ID
-        elif backend == "hdf5":
-            dosna_options["directory"] = options.get("dosna_hdf5_dir") \
-                or DEFAULT_HDF5_DIR
+        dosna_options.update(dict(item.split('=')
+                             for item in dosna_connection_options))
         log.debug("DosNa is using backend %s engine %s and options %s",
                   backend, engine, dosna_options)
         dn.use(engine, backend)

--- a/savu/tomo_recon.py
+++ b/savu/tomo_recon.py
@@ -102,12 +102,9 @@ def __option_parser():
                         default=None)
     parser.add_argument("--dosna_connection", dest="dosna_connection",
                         help=hide, default=None)
-    parser.add_argument("--dosna_ceph_conffile", dest="dosna_ceph_conffile",
-                        help=hide, default=None)
-    parser.add_argument("--dosna_ceph_client_id", dest="dosna_ceph_client_id",
-                        help=hide, default=None)
-    parser.add_argument("--dosna_hdf5_dir", dest="dosna_hdf5_dir",
-                        help=hide, default=None)
+    parser.add_argument("--dosna_connection_options",
+                        dest="dosna_connection_options", help=hide,
+                        nargs='+', default=[])
 
     check_help = "Continue Savu processing from a checkpoint."
     choices = ['plugin', 'subplugin']
@@ -174,9 +171,7 @@ def _set_options(args):
     options["dosna_backend"] = args.dosna_backend
     options["dosna_engine"] = args.dosna_engine
     options["dosna_connection"] = args.dosna_connection
-    options["dosna_ceph_conffile"] = args.dosna_ceph_conffile
-    options["dosna_ceph_client_id"] = args.dosna_ceph_client_id
-    options["dosna_hdf5_dir"] = args.dosna_hdf5_dir
+    options["dosna_connection_options"] = args.dosna_connection_options
 
     options['checkpoint'] = args.checkpoint
 


### PR DESCRIPTION
Backend specific parameters will be passed using:
--dosna_connection_options key=val [key2=val2]

With this change it's possible to use any dosna backend (not just ceph and hdf5)