### PR TITLE
Adds an error message for range based parameter tuning

### DIFF
--- a/savu/plugins/plugin.py
+++ b/savu/plugins/plugin.py
@@ -211,6 +211,10 @@ class Plugin(PluginDatasets):
                 seq = value[0].split(':')
                 seq = [eval(s) for s in seq]
                 value = list(np.arange(seq[0], seq[1], seq[2]))
+                if len(value) == 0:
+                    raise RuntimeError(
+                        'No values for tuned parameter "{}", '
+                        'ensure start:stop:step; values are valid.'.format(key))
             if type(value[0]) != dtype:
                 try:
                     value.remove('')


### PR DESCRIPTION
Covers the case when the supplied start:stop:step yield zero values (e.g. `-0.8:-0.4:0.1`).