### PR TITLE
Shrink Savu Docker image

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -5,10 +5,7 @@ MAINTAINER Matthew Frost
 USER root
 
 # Deps
-RUN yum groupinstall -y 'Development Tools'
-RUN yum -y install wget 
-RUN yum install -y mesa-libGL-devel mesa-libGLU-devel
-RUN yum install -y boost-devel
+RUN yum groupinstall -y 'Development Tools' && yum install -y mesa-libGL-devel mesa-libGLU-devel wget boost-devel && yum clean all && rm -rf /var/cache/yum
 
 ENV VERSION=2.2.1
 ENV FTTW=3.3.7
@@ -16,22 +13,22 @@ ENV OPENMPI=3.0.0
 
 # Install FTTW3
 ADD http://fftw.org/fftw-${FTTW}.tar.gz /fftw-${FTTW}.tar.gz
-RUN tar -xf fftw-${FTTW}.tar.gz
-RUN /fftw-${FTTW}/configure --enable-threads --enable-shared && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/
-RUN /fftw-${FTTW}/configure --enable-threads --enable-shared --enable-float && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/
-RUN /fftw-${FTTW}/configure --enable-threads --enable-shared --enable-long-double && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/
+RUN tar -xf fftw-${FTTW}.tar.gz && \
+    /fftw-${FTTW}/configure --enable-threads --enable-shared --disable-static && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/ && make clean /fftw-${FTTW}/ && \
+    /fftw-${FTTW}/configure --enable-threads --enable-shared --enable-float --disable-static && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/ && make clean /fftw-${FTTW}/ && \
+    /fftw-${FTTW}/configure --enable-threads --enable-shared --enable-long-double --disable-static && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/ && rm -rf /fftw*
 
 # Download openmpi ${OPENMPI} and build it 
 ADD https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-${OPENMPI}.tar.gz /openmpi-${OPENMPI}.tar.gz
-RUN tar -xf openmpi-${OPENMPI}.tar.gz 
-RUN /openmpi-${OPENMPI}/configure --with-sge --enable-orterun-prefix-by-default && make /openmpi-${OPENMPI}/ && make install /openmpi-${OPENMPI}/
+RUN tar -xf openmpi-${OPENMPI}.tar.gz && \
+    /openmpi-${OPENMPI}/configure --with-sge --enable-orterun-prefix-by-default --disable-static && make /openmpi-${OPENMPI}/ && make install /openmpi-${OPENMPI}/ && rm -rf /openmpi*
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Get and install Savu 
 COPY get-and-install-savu.sh /get-and-install-savu.sh
-RUN chmod +x /get-and-install-savu.sh
-RUN /get-and-install-savu.sh $VERSION
+RUN chmod +x /get-and-install-savu.sh && \
+    /get-and-install-savu.sh $VERSION
 
 ENV PATH=/root/miniconda/bin:$PATH
 

--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -7,9 +7,9 @@ USER root
 # Deps
 RUN yum groupinstall -y 'Development Tools' && yum install -y mesa-libGL-devel mesa-libGLU-devel wget boost-devel && yum clean all && rm -rf /var/cache/yum
 
-ENV VERSION=2.2.1
-ENV FTTW=3.3.7
-ENV OPENMPI=3.0.0
+ENV VERSION=2.3.1
+ENV FTTW=3.3.8
+ENV OPENMPI=3.1.3
 
 # Install FTTW3
 ADD http://fftw.org/fftw-${FTTW}.tar.gz /fftw-${FTTW}.tar.gz
@@ -19,7 +19,7 @@ RUN tar -xf fftw-${FTTW}.tar.gz && \
     /fftw-${FTTW}/configure --enable-threads --enable-shared --enable-long-double --disable-static && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/ && rm -rf /fftw*
 
 # Download openmpi ${OPENMPI} and build it 
-ADD https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-${OPENMPI}.tar.gz /openmpi-${OPENMPI}.tar.gz
+ADD https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-${OPENMPI}.tar.gz /openmpi-${OPENMPI}.tar.gz
 RUN tar -xf openmpi-${OPENMPI}.tar.gz && \
     /openmpi-${OPENMPI}/configure --with-sge --enable-orterun-prefix-by-default --disable-static && make /openmpi-${OPENMPI}/ && make install /openmpi-${OPENMPI}/ && rm -rf /openmpi*
 

--- a/docker-image/Singularity
+++ b/docker-image/Singularity
@@ -1,0 +1,45 @@
+Bootstrap: docker
+From: docker-registry.diamond.ac.uk/diamond-apps/nvidia/cuda:9.0-devel-centos7
+%files
+get-and-install-savu.sh /get-and-install-savu.sh
+
+%labels
+MAINTAINER Tom Schoonjans
+
+%post
+
+# Deps
+yum groupinstall -y 'Development Tools' && yum install -y mesa-libGL-devel mesa-libGLU-devel wget boost-devel && yum clean all && rm -rf /var/cache/yum
+
+VERSION=2.3.1
+FTTW=3.3.8
+OPENMPI=3.1.3
+
+# Download openmpi ${OPENMPI} and build it 
+wget https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-${OPENMPI}.tar.gz
+tar -xf openmpi-${OPENMPI}.tar.gz && \
+/openmpi-${OPENMPI}/configure --with-sge --enable-orterun-prefix-by-default --disable-static && make /openmpi-${OPENMPI}/ && make install /openmpi-${OPENMPI}/ && rm -rf /openmpi*
+
+# Install FTTW3
+wget http://fftw.org/fftw-${FTTW}.tar.gz
+tar -xf fftw-${FTTW}.tar.gz && \
+/fftw-${FTTW}/configure --enable-threads --enable-shared --disable-static && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/ && make clean /fftw-${FTTW}/ && \
+/fftw-${FTTW}/configure --enable-threads --enable-shared --enable-float --disable-static && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/ && make clean /fftw-${FTTW}/ && \
+/fftw-${FTTW}/configure --enable-threads --enable-shared --enable-long-double --disable-static && make /fftw-${FTTW}/ && make install /fftw-${FTTW}/ && rm -rf /fftw*
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+export PATH=/usr/local/bin:/usr/local/cuda/bin:$PATH
+
+# Get and install Savu 
+chmod +x /get-and-install-savu.sh && \
+/get-and-install-savu.sh $VERSION
+
+%environment
+export VERSION=2.3.1
+export FTTW=3.3.8
+export OPENMPI=3.1.3
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+export PATH=/usr/local/miniconda/bin:$PATH
+
+%runscript
+exec /bin/bash "$@"

--- a/docker-image/Singularity
+++ b/docker-image/Singularity
@@ -11,14 +11,27 @@ MAINTAINER Tom Schoonjans
 # Deps
 yum groupinstall -y 'Development Tools' && yum install -y mesa-libGL-devel mesa-libGLU-devel wget boost-devel && yum clean all && rm -rf /var/cache/yum
 
+# Mellanox deps
+yum install -y libnl libnl3 numactl-libs numactl-devel hwloc
+
+
 VERSION=2.3.1
 FTTW=3.3.8
 OPENMPI=3.1.3
 
+# Download Mellanox and install it
+wget http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.6-x86_64.tgz
+tar xvfz MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.6-x86_64.tgz
+cd MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.6-x86_64/RPMS
+yum localinstall -y libibverbs-*.x86_64.rpm libibverbs-devel-*.x86_64.rpm libibverbs-utils-*.x86_64.rpm libibmad-*.x86_64.rpm libibmad-devel-*.x86_64.rpm libibumad-*.x86_64.rpm libibumad-devel-*.x86_64.rpm libmlx4-*.x86_64.rpm libmlx4-devel-*.x86_64.rpm libmlx5-*.x86_64.rpm libmlx5-devel-*.x86_64.rpm librdmacm-devel-*.x86_64.rpm librdmacm-*.x86_64.rpm
+cd ../..
+rm -rf MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.6-x86_64*
+
+
 # Download openmpi ${OPENMPI} and build it 
 wget https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-${OPENMPI}.tar.gz
 tar -xf openmpi-${OPENMPI}.tar.gz && \
-/openmpi-${OPENMPI}/configure --with-sge --enable-orterun-prefix-by-default --disable-static && make /openmpi-${OPENMPI}/ && make install /openmpi-${OPENMPI}/ && rm -rf /openmpi*
+/openmpi-${OPENMPI}/configure --with-verbs --with-sge --enable-orterun-prefix-by-default --disable-static && make /openmpi-${OPENMPI}/ && make install /openmpi-${OPENMPI}/ && rm -rf /openmpi*
 
 # Install FTTW3
 wget http://fftw.org/fftw-${FTTW}.tar.gz

--- a/docker-image/get-and-install-savu.sh
+++ b/docker-image/get-and-install-savu.sh
@@ -25,4 +25,4 @@ tar -xvzf savu.tar.gz
 
 cd savu_v${VERSION}
 chmod +x savu_installer.sh
-./savu_installer.sh --no_prompts | tee savu_installation.log
+PREFIX=/usr/local ./savu_installer.sh --no_prompts | tee savu_installation.log


### PR DESCRIPTION
1. Reduce number of layers
2. Perform yum cleanup
3. Disable static builds of fftw and open-mpi
4. Remove fftw and open-mpi tarballs and unpacked directories

I saved around 0.5 GB this way...