### PR TITLE
Fix issue with multidigit number is hdf5 template stitch_data

### DIFF
--- a/savu/plugins/loaders/hdf5_template_loader.py
+++ b/savu/plugins/loaders/hdf5_template_loader.py
@@ -73,10 +73,12 @@ class Hdf5TemplateLoader(YamlConverter):
 
         number = []
         for m in matches:
+            diff_number = ''
             for diff in difflib.ndiff(m, data_name):
                 split = diff.split('- ')
                 if len(split) > 1:
-                    number.append(int(split[-1]))
+                    diff_number += split[-1]
+            number.append(int(diff_number))
 
         matches = [matches[i] for i in np.argsort(number)]
         dObj.data_info.set('wildcard_values', sorted(number))


### PR DESCRIPTION
Fixes issue where multidigit numbers weren't being correctly matched in the stitch_data() function in hdf5_template_loader