### PR TITLE
Fix problem in yaml converter when savu in path

### DIFF
--- a/savu/plugins/loaders/yaml_converter.py
+++ b/savu/plugins/loaders/yaml_converter.py
@@ -69,7 +69,8 @@ class YamlConverter(BaseLoader):
             raise Exception('Please pass a yaml file to the yaml loader.')
 
         if not os.path.exists(yaml_file):
-            path = os.path.dirname(__file__.split('savu')[0])
+            path = os.path.dirname(
+                __file__.split(os.path.join('savu', 'plugins'))[0])
             yaml_file = os.path.join(path, yaml_file)
             if not os.path.exists(yaml_file):
                 raise Exception('The yaml file does not exist %s' % yaml_file)


### PR DESCRIPTION
Fixes the problem when the word "savu" appears more than once in the path to savu.
This fix checks for savu/plugins which should be the "base" location of the yaml_converter file, and hence the plugins for finding yaml files within the savu plugins directory.