### PR TITLE
Fixed dosna transport

### DIFF
--- a/savu/core/transports/dosna_transport.py
+++ b/savu/core/transports/dosna_transport.py
@@ -94,7 +94,7 @@ class DosnaTransport(BaseTransport):
         # loaders have completed now revert back to DosnaTransport, so any
         # output datasets created by a plugin will use this.
         self.hdf5 = Hdf5Utils(self.exp)
-        exp_coll = self.exp._get_experiment_collection()
+        exp_coll = self.exp._get_collection()
         self.data_flow = self.exp.meta_data.plugin_list._get_dataset_flow()
         #self.exp.meta_data.set('transport', 'dosna')
         plist = self.exp.meta_data.plugin_list


### PR DESCRIPTION
Changed exp_coll to represent change in commit 4a6b69109848a91bda5681a82552a61674dc95fc, where self.exp._get_experiment_collection() became self.exp._get_collection(), fixing the dosna transport plugin.